### PR TITLE
Fix verbose progress leaking into redirected stdout

### DIFF
--- a/pkg/client/transcribe.go
+++ b/pkg/client/transcribe.go
@@ -301,22 +301,22 @@ func (c *GladiaClient) pollForTranscriptionResult(resultURL string) (*Transcript
 
 		if result.Status == "done" {
 			if c.Verbose {
-				fmt.Printf("\033[H\033[2J") // Clear the terminal screen
-				fmt.Println("Transcription completed successfully.")
-				fmt.Printf("\033[H\033[2J") // Clear the terminal screen
+				fmt.Fprintf(os.Stderr, "\033[H\033[2J") // Clear the terminal screen
+				fmt.Fprintln(os.Stderr, "Transcription completed successfully.")
+				fmt.Fprintf(os.Stderr, "\033[H\033[2J") // Clear the terminal screen
 			}
 			return &result, nil
 		}
 
 		if result.Status == "error" {
 			if c.Verbose {
-				fmt.Printf("\033[H\033[2J") // Clear the terminal screen
+				fmt.Fprintf(os.Stderr, "\033[H\033[2J") // Clear the terminal screen
 			}
 			return nil, fmt.Errorf("transcription failed with error: %s", result.Result.Transcription.FullTranscript)
 		}
 
 		if c.Verbose {
-			fmt.Printf("\rTranscription in progress... %s     (%s) (request_id: %s)",
+			fmt.Fprintf(os.Stderr, "\rTranscription in progress... %s     (%s) (request_id: %s)",
 				spinner[spinnerIndex],
 				result.Status,
 				result.RequestID)

--- a/pkg/client/transcribe_test.go
+++ b/pkg/client/transcribe_test.go
@@ -146,6 +146,60 @@ func TestPollForTranscriptionResult_errorStatus(t *testing.T) {
 	}
 }
 
+func TestPollForTranscriptionResult_verboseGoesToStderr(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			_, _ = w.Write([]byte(`{"status":"processing","request_id":"G-test"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"done","request_id":"G-test","result":{"transcription":{"full_transcript":"ok"}}}`))
+	}))
+	defer server.Close()
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = stdoutW, stderrW
+
+	c := NewGladiaClient("k", true, "dev")
+	c.GladiaEndpoint = server.URL
+	_, pollErr := c.pollForTranscriptionResult(server.URL + "/status")
+
+	stdoutW.Close()
+	stderrW.Close()
+	os.Stdout, os.Stderr = oldStdout, oldStderr
+
+	if pollErr != nil {
+		t.Fatal(pollErr)
+	}
+
+	stdoutBuf := make([]byte, 1<<20)
+	nOut, _ := stdoutR.Read(stdoutBuf)
+	stdout := string(stdoutBuf[:nOut])
+
+	stderrBuf := make([]byte, 1<<20)
+	nErr, _ := stderrR.Read(stderrBuf)
+	stderr := string(stderrBuf[:nErr])
+
+	if stdout != "" {
+		t.Fatalf("stdout should be empty, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "Transcription in progress...") {
+		t.Fatalf("stderr missing progress: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Transcription completed successfully.") {
+		t.Fatalf("stderr missing success message: %q", stderr)
+	}
+}
+
 func TestDecodeAPIError(t *testing.T) {
 	c := NewGladiaClient("k", false, "dev")
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- Send `-v` progress/spinner messages to stderr instead of stdout
- Keeps redirected output (`> output.json`) as clean JSON only

## Test plan
- [ ] `gladia transcribe <url> -o json -v > output.json` — file is valid JSON, progress still shows in the terminal
- [ ] `go test ./pkg/client/ -run TestPollForTranscriptionResult_verboseGoesToStderr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verbose transcription progress, completion, and error messages are now sent to the error output stream instead of standard output.
  * Prevents status messages from interfering with normal command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->